### PR TITLE
COREX-346 CoreDataService keeps crashing

### DIFF
--- a/src/ServiceModel/ServiceModel/ServiceModel/Discovery/DefaultAnnouncementClientWrapper.cs
+++ b/src/ServiceModel/ServiceModel/ServiceModel/Discovery/DefaultAnnouncementClientWrapper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ServiceModel;
 using System.ServiceModel.Discovery;
 
 namespace EMG.Utilities.ServiceModel.Discovery
@@ -24,7 +25,16 @@ namespace EMG.Utilities.ServiceModel.Discovery
 
         public void Dispose()
         {
-            ((IDisposable)_client).Dispose();
+            var communicationObject = _client as ICommunicationObject;
+
+            if (communicationObject.State != CommunicationState.Faulted)
+            {
+                ((IDisposable)_client).Dispose();
+            }
+            else 
+            {
+                communicationObject.Abort();
+            }
         }
     }
 }


### PR DESCRIPTION
- Call Abort on communicationObject when disposing AnnouncementClient in case it is in Faulted state

![Error](https://github.com/keghub/dotnet-utils/assets/17877224/5d37b33d-6221-4da9-9751-bf79003ee261)
