### PR TITLE
COREX-383 Builds failing due to netcoreapp2.X - dotnet-utils

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ nuget:
   disable_publish_on_pr: true
 
 install:
-  - cmd: dotnet tool install -g Cake.Tool --version 0.33.0
+  - cmd: dotnet tool install -g Cake.Tool --version 1.3.0
 
 build_script:
   - cmd: dotnet cake --target=Full

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ nuget:
   disable_publish_on_pr: true
 
 install:
-  - cmd: dotnet tool install -g Cake.Tool --version 1.3.0
+  - cmd: dotnet tool install -g Cake.Tool --version 4.0.0
 
 build_script:
   - cmd: dotnet cake --target=Full

--- a/build.cake
+++ b/build.cake
@@ -49,25 +49,25 @@ Task("Version")
 Task("Restore")
     .Does<BuildState>(state =>
 {
-    var settings = new DotNetCoreRestoreSettings
+    var settings = new DotNetRestoreSettings
     {
 
     };
 
-    DotNetCoreRestore(state.Paths.SolutionFile.ToString(), settings);
+    DotNetRestore(state.Paths.SolutionFile.ToString(), settings);
 });
 
 Task("Build")
     .IsDependentOn("Restore")
     .Does<BuildState>(state => 
 {
-    var settings = new DotNetCoreBuildSettings
+    var settings = new DotNetBuildSettings
     {
         Configuration = "Debug",
         NoRestore = true
     };
 
-    DotNetCoreBuild(state.Paths.SolutionFile.ToString(), settings);
+    DotNetBuild(state.Paths.SolutionFile.ToString(), settings);
 });
 
 Task("RunTests")
@@ -101,16 +101,16 @@ Task("RunTests")
                                         .WithFilter("-:Tests*")
                                         .WithFilter("-:TestUtils");
 
-                var settings = new DotNetCoreTestSettings
+                var settings = new DotNetTestSettings
                 {
                     NoBuild = true,
                     NoRestore = true,
-                    Logger = $"trx;LogFileName={testResultFile.FullPath}",
+                    Loggers = new[] { $"trx;LogFileName={testResultFile.FullPath}" },
                     Filter = "TestCategory!=External",
                     Framework = framework
                 };
 
-                DotCoverCover(c => c.DotNetCoreTest(projectFile, settings), coverageResultFile, dotCoverSettings);
+                DotCoverCover(c => c.DotNetTest(projectFile, settings), coverageResultFile, dotCoverSettings);
             }
             catch (Exception ex)
             {
@@ -208,7 +208,7 @@ Task("PackLibraries")
     .IsDependentOn("Restore")
     .Does<BuildState>(state =>
 {
-    var settings = new DotNetCorePackSettings
+    var settings = new DotNetPackSettings
     {
         Configuration = "Release",
         NoRestore = true,
@@ -217,7 +217,7 @@ Task("PackLibraries")
         ArgumentCustomization = args => args.Append($"-p:SymbolPackageFormat=snupkg -p:Version={state.Version.PackageVersion}")
     };
 
-    DotNetCorePack(state.Paths.SolutionFile.ToString(), settings);
+    DotNetPack(state.Paths.SolutionFile.ToString(), settings);
 });
 
 Task("Pack")

--- a/tests/Tests.Clock/SystemClockTests.cs
+++ b/tests/Tests.Clock/SystemClockTests.cs
@@ -11,7 +11,7 @@ namespace Tests
         [Test, AutoData]
         public void UtcNow_returns_current_time()
         {
-            Assert.That(SystemClock.Instance.UtcNow, Is.EqualTo(DateTimeOffset.UtcNow).Within(TimeSpan.FromTicks(100)));
+            Assert.That(SystemClock.Instance.UtcNow, Is.EqualTo(DateTimeOffset.UtcNow).Within(TimeSpan.FromTicks(2000)));
         }
     }
 }

--- a/tests/Tests.Clock/Tests.Clock.csproj
+++ b/tests/Tests.Clock/Tests.Clock.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;net47</TargetFrameworks>
+    <TargetFrameworks>net47;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/Tests.Hosting.TopShelf/Tests.Hosting.TopShelf.csproj
+++ b/tests/Tests.Hosting.TopShelf/Tests.Hosting.TopShelf.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;net47</TargetFrameworks>
+    <TargetFrameworks>net47;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/Tests.NybusBridge/Tests.NybusBridge.csproj
+++ b/tests/Tests.NybusBridge/Tests.NybusBridge.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;net47</TargetFrameworks>
+    <TargetFrameworks>net47;net8.0</TargetFrameworks>
     <RootNamespace>Tests</RootNamespace>
     <IsPackable>false</IsPackable>
     <AssemblyName>Tests.NybusBridge</AssemblyName>


### PR DESCRIPTION
- Update cake tool version (done by Erik)
- Update cake file replace DotNetCore settings and commands
- Update target framework from netcoreapp2.2 to net8.0 in test projects