### PR TITLE
COREX-346 CoreDataService keeps crashing

### DIFF
--- a/src/ServiceModel/ServiceModel/ServiceModel/Discovery/DefaultAnnouncementClientWrapperFactory.cs
+++ b/src/ServiceModel/ServiceModel/ServiceModel/Discovery/DefaultAnnouncementClientWrapperFactory.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using System;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
@@ -7,13 +8,20 @@ namespace EMG.Utilities.ServiceModel.Discovery
 {
     public class DefaultAnnouncementClientWrapperFactory : IAnnouncementClientWrapperFactory
     {
+        private readonly ILogger<DefaultAnnouncementClientWrapper> _logger;
+
+        public DefaultAnnouncementClientWrapperFactory(ILogger<DefaultAnnouncementClientWrapper> logger)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
         public IAnnouncementClientWrapper Create(Uri registryUrl, Binding binding)
         {
             var endpointAddress = new EndpointAddress(registryUrl);
             var endpoint = new AnnouncementEndpoint(binding, endpointAddress);
             var client = new AnnouncementClient(endpoint);
 
-            var wrapper = new DefaultAnnouncementClientWrapper(client);
+            var wrapper = new DefaultAnnouncementClientWrapper(client, _logger);
 
             return wrapper;
         }


### PR DESCRIPTION
- Add error handling when disposing AnnouncementClient

We noticed that sometime TimeoutException is thrown when closing communication object on AnnouncementClient.
By adding error handling we want to ensure that even If the close operation fails or times out, we fallback to aborting the object to ensure proper cleanup.